### PR TITLE
Add extra check for Javascript interop code if it is "null" (was only checking for undefined before

### DIFF
--- a/src/components/UpdatePriceModal.re
+++ b/src/components/UpdatePriceModal.re
@@ -7,7 +7,7 @@ module Transaction = {
   [@react.component]
   let make = (~gorilla: Gorilla.gorilla) => {
     let (newBuyPrice, setNewBuyPrice) = React.useState(() => "");
-    let currentPrice = useCurrentPriceWei();
+    let currentPrice = useCurrentPriceWei()->mapWithDefault("loading", a => a);
     let currentUser = useCurrentUser();
     // let changePriceObj = useChangePriceTransaction();
     // let changePriceObjNew = useChangePriceTransactionNew();

--- a/src/helpers/hooks/Hooks.re
+++ b/src/helpers/hooks/Hooks.re
@@ -19,8 +19,10 @@ let useWeb3: unit => Web3.t =
 
 let useTotalPatronageWei = () => {
   let totalCollectedOpt =
-    useCacheCall((), "VitalikSteward", "totalCollected");
-  let patronageOwedOpt = useCacheCall((), "VitalikSteward", "patronageOwed");
+    useCacheCall((), "VitalikSteward", "totalCollected")
+    ->Js.Nullable.toOption;
+  let patronageOwedOpt =
+    useCacheCall((), "VitalikSteward", "patronageOwed")->Js.Nullable.toOption;
   switch (totalCollectedOpt, patronageOwedOpt) {
   | (Some(totalCollected), Some(patronageOwed)) =>
     let totalCollectedBN: BN.bn = BN.new_(totalCollected);
@@ -47,7 +49,8 @@ let useTotalPatronageUsd = () => {
 };
 
 let useDepositAbleToWithdrawWei = () =>
-  useCacheCall((), "VitalikSteward", "depositAbleToWithdraw");
+  useCacheCall((), "VitalikSteward", "depositAbleToWithdraw")
+  ->Js.Nullable.toOption;
 
 let useDepositAbleToWithdrawEth = () =>
   useDepositAbleToWithdrawWei()->flatMap(price => Some(fromWeiToEth(price)));
@@ -64,11 +67,13 @@ let useDepositAbleToWithdrawUsd = () => {
 
 let useForeclosureTime = () =>
   useCacheCall((), "VitalikSteward", "foreclosureTime")
+  ->Js.Nullable.toOption
   ->Belt.Option.map(stringTimeStamp =>
       MomentRe.momentWithUnix(int_of_string(stringTimeStamp))
     );
 
-let useCurrentPriceWei = () => useCacheCall((), "VitalikSteward", "price");
+let useCurrentPriceWei = () =>
+  useCacheCall((), "VitalikSteward", "price")->Js.Nullable.toOption;
 let useCurrentPriceEth = () =>
   useCurrentPriceWei()->flatMap(price => Some(fromWeiToEth(price)));
 let useCurrentPriceUsd = () => {
@@ -83,12 +88,13 @@ let useCurrentPriceUsd = () => {
 };
 
 let useCurrentPatron: unit => option(string) =
-  () => (useCacheCall())(. "ERC721Full", "ownerOf", 42);
+  () => (useCacheCall())(. "ERC721Full", "ownerOf", 42)->Js.Nullable.toOption;
 // let useTotalTimeHeld = (addressOfUser) =>
 //       let currentTimeHeld = parseInt(this.getTimeHeld(props, timeHeldKey)) + (parseInt(date.getTime()/1000) - parseInt(this.getTimeAcquired(props))
 
 let useAvailableDeposit = () =>
-  useCacheCall((), "VitalikSteward", "availableDeposit");
+  useCacheCall((), "VitalikSteward", "availableDeposit")
+  ->Js.Nullable.toOption;
 let useBuyTransaction = () => (useCacheSend())(. "VitalikSteward", "buy");
 let useChangePriceTransaction = () =>
   (useCacheSend())(. "VitalikSteward", "changePrice");

--- a/src/helpers/hooks/NewHooks.re
+++ b/src/helpers/hooks/NewHooks.re
@@ -83,12 +83,14 @@ let useWithdrawTransactionNew = () =>
 // TODO: this should use a BN not an int (int is bad :D)
 let useCurrentPatronNew: int => option(string) = {
   tokenId =>
-    (useCacheCall())(. "WildcardSteward_v0", "currentPatron", tokenId);
+    (useCacheCall())(. "WildcardSteward_v0", "currentPatron", tokenId)
+    ->Js.Nullable.toOption;
 };
 let useBuyTransactionNew = () =>
   (useCacheSend())(. "WildcardSteward_v0", "buy");
 let useDepositAvailableToWithdrawNew = patron =>
-  (useCacheCall())(. "WildcardSteward_v0", "depositAbleToWithdraw", patron);
+  (useCacheCall())(. "WildcardSteward_v0", "depositAbleToWithdraw", patron)
+  ->Js.Nullable.toOption;
 // let useAvailableDepositNew = patron =>
 //   (useCacheCall())(. "WildcardSteward_v0", "depositAbleToWithdraw", patron);
 

--- a/src/helpers/hooks/PureHooks.re
+++ b/src/helpers/hooks/PureHooks.re
@@ -5,9 +5,9 @@ type drizzle = {web3: Web3.t};
 type drizzleContext = {
   drizzle,
   [@bs.as "useCacheCall"]
-  useCacheCallStr: (. string, string, TokenId.t) => option(string),
+  useCacheCallStr: (. string, string, TokenId.t) => Js.Nullable.t(string),
   [@bs.as "useCacheCall"]
-  useCacheCallVitalikStr: (. string, string) => option(string),
+  useCacheCallVitalikStr: (. string, string) => Js.Nullable.t(string),
 };
 
 [@bs.deriving {abstract: light}]
@@ -37,8 +37,10 @@ let useCacheCallVitalikStr = method =>
   useDrizzle()->useCacheCallVitalikStr(. "VitalikSteward", method);
 
 let useTotalPatronageWei = id => {
-  let totalCollectedOpt = "totalCollected"->useCacheCallStr(id);
-  let patronageOwedOpt = "patronageOwed"->useCacheCallStr(id);
+  let totalCollectedOpt =
+    "totalCollected"->useCacheCallStr(id)->Js.Nullable.toOption;
+  let patronageOwedOpt =
+    "patronageOwed"->useCacheCallStr(id)->Js.Nullable.toOption;
 
   switch (totalCollectedOpt, patronageOwedOpt) {
   | (Some(totalCollected), Some(patronageOwed)) =>
@@ -50,14 +52,16 @@ let useTotalPatronageWei = id => {
 };
 
 let useTimeAcquired = id => {
-  let timeAquiredRaw = "timeAcquired"->useCacheCallStr(id);
+  let timeAquiredRaw =
+    "timeAcquired"->useCacheCallStr(id)->Js.Nullable.toOption;
 
   timeAquiredRaw->Belt.Option.flatMap(timeStamp =>
     Some(MomentRe.momentWithUnix(int_of_string(timeStamp)))
   );
 };
 let useTimeAcquiredVitalik = () => {
-  let timeAcquiredRaw = "timeAcquired"->useCacheCallVitalikStr;
+  let timeAcquiredRaw =
+    "timeAcquired"->useCacheCallVitalikStr->Js.Nullable.toOption;
 
   timeAcquiredRaw->Belt.Option.flatMap(timeStamp =>
     Some(MomentRe.momentWithUnix(int_of_string(timeStamp)))

--- a/src/wrappedLibs/drizzle-react/jsDrizzleReactHooks.js
+++ b/src/wrappedLibs/drizzle-react/jsDrizzleReactHooks.js
@@ -2,24 +2,24 @@ import { drizzleReactHooks } from '@drizzle/react-plugin'
 
 export const useGetAvailableDeposit = (userAddress) => {
   const { useCacheCall } = drizzleReactHooks.useDrizzle()
-  return useCacheCall("WildcardSteward_v0", 'depositAbleToWithdraw', userAddress)
+  return useCacheCall("WildcardSteward_v0", 'depositAbleToWithdraw', userAddress) || undefined
 }
 
 export const useGetPrice = (tokenId) => {
   const { useCacheCall } = drizzleReactHooks.useDrizzle()
-  return useCacheCall("WildcardSteward_v0", 'price', tokenId)
+  return useCacheCall("WildcardSteward_v0", 'price', tokenId) || undefined
 }
 export const useGetTotalCollected = (tokenId) => {
   const { useCacheCall } = drizzleReactHooks.useDrizzle()
-  return useCacheCall("WildcardSteward_v0", 'totalCollected', tokenId)
+  return useCacheCall("WildcardSteward_v0", 'totalCollected', tokenId) || undefined
 }
 export const useGetPatronageOwed = (tokenId) => {
   const { useCacheCall } = drizzleReactHooks.useDrizzle()
-  return useCacheCall("WildcardSteward_v0", 'patronageOwed', tokenId)
+  return useCacheCall("WildcardSteward_v0", 'patronageOwed', tokenId) || undefined
 }
 export const useGetForeclosureTime = (tokenId) => {
   const { useCacheCall } = drizzleReactHooks.useDrizzle()
-  return useCacheCall("WildcardSteward_v0", 'foreclosureTime', tokenId)
+  return useCacheCall("WildcardSteward_v0", 'foreclosureTime', tokenId) || undefined
 }
 
 export const useUserBalance = () => {


### PR DESCRIPTION
Some background: https://reasonml.github.io/docs/en/null-undefined-option#solution-more-sophisticated-undefined-null-interop

Basically (for efficiency purposes), Reason `option` type only checks for javascript `undefined` but not `null`.