### PR TITLE
If the user has never owned a token previously, don't show "previously owned tokens"

### DIFF
--- a/src/components/UserProfile.re
+++ b/src/components/UserProfile.re
@@ -183,7 +183,7 @@ module UserDetails = {
                <br />
                <br />
                {switch (uniquePreviouslyOwnedTokens) {
-                | [||] => <p> "User has never owned a wildcard."->restr </p>
+                | [||] => React.null
                 | uniquePreviouslyOwnedTokens =>
                   <React.Fragment>
                     <Rimble.Heading>


### PR DESCRIPTION
Very simple fix, not much to worry about here :)
If there are no previously owned tokens it now shows nothing (we could have a message saying "user hasn't owned any tokens previously".